### PR TITLE
Fix incorrect href to news.js.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ zodiac: true
          Ready for some number crunching? <strong><a href="https://stats.js.org">STATS.JS.ORG</a></strong> fetches statistical parameters for the most important JavaScript projects on GitHub and stuffs them in a giant table with 10k rows. This project aims to make trends of JavaScript visible.
       </li>
       <li>
-         <h3><a href="https://news.js.org">NEWS</a></h3>
-         You have something to share with the community or want to read about the stuff other JavaScript enthusiasts do? <strong><a href="https://news.js.org">NEWS.JS.ORG</a></strong> provides a way to easily spread, consume and discuss JavaScript projects.
+         <h3><a href="http://news.js.org">NEWS</a></h3>
+         You have something to share with the community or want to read about the stuff other JavaScript enthusiasts do? <strong><a href="http://news.js.org">NEWS.JS.ORG</a></strong> provides a way to easily spread, consume and discuss JavaScript projects.
       </li>
    </ul>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ zodiac: true
          Ready for some number crunching? <strong><a href="https://stats.js.org">STATS.JS.ORG</a></strong> fetches statistical parameters for the most important JavaScript projects on GitHub and stuffs them in a giant table with 10k rows. This project aims to make trends of JavaScript visible.
       </li>
       <li>
-         <h3><a href="http://news.js.org">NEWS</a></h3>
-         You have something to share with the community or want to read about the stuff other JavaScript enthusiasts do? <strong><a href="news.js.org">NEWS.JS.ORG</a></strong> provides a way to easily spread, consume and discuss JavaScript projects.
+         <h3><a href="https://news.js.org">NEWS</a></h3>
+         You have something to share with the community or want to read about the stuff other JavaScript enthusiasts do? <strong><a href="https://news.js.org">NEWS.JS.ORG</a></strong> provides a way to easily spread, consume and discuss JavaScript projects.
       </li>
    </ul>


### PR DESCRIPTION
URL to the NEWS section was non absolute (thus throwing a 404 to http://js.org/news.js.org)
